### PR TITLE
Add the cURL extension and command requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 ## Requirements
 
-- PHP >= 7.1
-- Bash is available.
+- PHP >= 7.1 and the cURL extension is available.
+- Bash and cURL command are available.
 
 ### PHP
 


### PR DESCRIPTION
# Changed log

- After looking at the `check_and_notify.php` and `check_and_notify.sh` files, it should add the `cURL` extension and command to let developers know these should be available for running the PHP program or Bash script.